### PR TITLE
Delete env vars to force default URL where appropriate

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,12 +83,20 @@ async function main() {
     const results: LatencyData[] = [];
 
     for (const runner of runners) {
+        // TODO: This should not be how env vars are used, we should consider
+        // using a config file or some other method to manage these provider URLs
+
         // Set environment variables based on provider key
         if (runner.providerKey) {
             process.env.EVM_MAINNET_RPC_ENDPOINT_URL =
                 process.env[`MAINNET_${runner.providerKey}`];
             process.env.EVM_TESTNET_RPC_ENDPOINT_URL =
                 process.env[`TESTNET_${runner.providerKey}`];
+        } else {
+            // If no provider key, we have to delete the variables to ensure proper
+            // selection of the default provider
+            delete process.env.EVM_MAINNET_RPC_ENDPOINT_URL;
+            delete process.env.EVM_TESTNET_RPC_ENDPOINT_URL;
         }
 
         if (typeof runner.network === "string") {


### PR DESCRIPTION
Previously, we noticed a discrepancy with the results that seem to imply that the default evm gateways were not on soft finality.

In the end we discovered that it was the tests that continued to talk to the Alchemy endpoints rather than talking to the public endpoints.

Reason for this was because the env vars were set during the running of the testnet runners, and therefore stayed set for the "default" runs on mainnet.

A temp fix was to move all default runs, or provider: undefined runs to the top, and all alchemy provider runners to the bottom.

This is a slightly more proper fix so that even if the order of the runners get moved, it should still behave properly.

However, the most ideal solution is likely not to use process.env in this way at all, and simply make proper use of the src/utils/config.tx file, which i don't feel like we are currently.